### PR TITLE
Feat/geolocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This application was a part of a Rocketseat course for practice the React Hooks 
 - [ReactJS](https://react.dev/learn)
 - [TypeScript](https://www.typescriptlang.org/)
 - [Styled Components](https://styled-components.com/)
+- [React Hot Toast](https://react-hot-toast.com/)
 - [React Hook Form](https://react-hook-form.com/)
 - [Zod](https://zod.dev/)
 - [Google Fonts](https://fonts.google.com/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.56.3",
+        "react-hot-toast": "^2.5.2",
         "react-router-dom": "^6.30.0",
         "styled-components": "^6.1.18",
         "zod": "^3.24.4"
@@ -2396,6 +2397,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -2948,6 +2958,23 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.5.2.tgz",
+      "integrity": "sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.56.3",
+    "react-hot-toast": "^2.5.2",
     "react-router-dom": "^6.30.0",
     "styled-components": "^6.1.18",
     "zod": "^3.24.4"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,15 +4,18 @@ import { GlobalStyle } from "./styles/global";
 import { BrowserRouter } from "react-router-dom";
 import { Router } from "./Routes";
 import { CartContextProvider } from "./contexts/CartContext";
+import { LocationContextProvider } from "./contexts/LocationContext";
 
 function App() {
   return (
     <ThemeProvider theme={defaultTheme}>
       <GlobalStyle />
       <BrowserRouter>
-        <CartContextProvider>
-          <Router />
-        </CartContextProvider>
+        <LocationContextProvider>
+          <CartContextProvider>
+            <Router />
+          </CartContextProvider>
+        </LocationContextProvider>
       </BrowserRouter>
     </ThemeProvider>
   );

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -3,7 +3,8 @@ import {
   ActionButtonsContainer,
   CartButton,
   HeaderContainer,
-  LocationButton
+  LocationButton,
+  SpinningIcon
 } from "./styles";
 
 import coffeeDeliveryLogo from "../../assets/coffee-delivery-logo.svg";
@@ -15,7 +16,7 @@ import { useLocation } from "../../contexts/LocationContext";
 
 export function Header() {
   const { cart } = useContext(CartContext);
-  const { location } = useLocation();
+  const { location, isLoading, locationError } = useLocation();
 
   const navigate = useNavigate();
 
@@ -23,7 +24,7 @@ export function Header() {
     navigate("/checkout");
   }
 
-  console.log("location: ", location);
+  console.log("locationError: ", locationError);
 
   return (
     <HeaderContainer>
@@ -35,8 +36,12 @@ export function Header() {
 
           <ActionButtonsContainer>
             <LocationButton>
-              <MapPin size={20} weight="fill" />
-              Porto Alegre, RS
+              {isLoading || !location ? <SpinningIcon size={20} /> : (
+                <>
+                  <MapPin size={20} weight="fill" />
+                  {location.city}, {location.state}
+                </>
+              )}              
             </LocationButton>
             
             <CartButton type="button" onClick={handleCheckoutButton}>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -11,15 +11,19 @@ import { MapPin, ShoppingCart } from "@phosphor-icons/react";
 import { Link, useNavigate } from "react-router-dom";
 import { useContext } from "react";
 import { CartContext } from "../../contexts/CartContext";
+import { useLocation } from "../../contexts/LocationContext";
 
 export function Header() {
   const { cart } = useContext(CartContext);
+  const { location } = useLocation();
 
   const navigate = useNavigate();
 
   function handleCheckoutButton() {
     navigate("/checkout");
   }
+
+  console.log("location: ", location);
 
   return (
     <HeaderContainer>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -10,12 +10,14 @@ import {
 import coffeeDeliveryLogo from "../../assets/coffee-delivery-logo.svg";
 import { MapPin, ShoppingCart } from "@phosphor-icons/react";
 import { Link, useNavigate } from "react-router-dom";
-import { useContext } from "react";
+import { useContext, useEffect, useState } from "react";
 import { CartContext } from "../../contexts/CartContext";
 import { useLocation } from "../../contexts/LocationContext";
+import toast, { Toaster } from "react-hot-toast";
 
 export function Header() {
   const { cart } = useContext(CartContext);
+  const [isToastedLoaded, setIsToastedLoaded] = useState(false);
   const { location, isLoading, locationError } = useLocation();
 
   const navigate = useNavigate();
@@ -24,7 +26,20 @@ export function Header() {
     navigate("/checkout");
   }
 
-  console.log("locationError: ", locationError);
+  function handleLocationInfo() {
+    if (locationError !== "") {
+      toast.error(locationError);
+    } else {
+      toast.success("Sua localização está ativa!");
+    }
+  }
+
+  useEffect(() => {
+    if (!isToastedLoaded && locationError !== "") {
+      setIsToastedLoaded(true);
+      toast.error(locationError);
+    }
+  }, [isToastedLoaded, locationError]);
 
   return (
     <HeaderContainer>
@@ -35,7 +50,7 @@ export function Header() {
           </Link>
 
           <ActionButtonsContainer>
-            <LocationButton>
+            <LocationButton onClick={handleLocationInfo}>
               {isLoading || !location ? <SpinningIcon size={20} /> : (
                 <>
                   <MapPin size={20} weight="fill" />
@@ -43,6 +58,7 @@ export function Header() {
                 </>
               )}              
             </LocationButton>
+            <Toaster />
             
             <CartButton type="button" onClick={handleCheckoutButton}>
               {cart.length > 0 && <span>{cart.length}</span>}

--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -1,5 +1,6 @@
-import styled from "styled-components";
+import styled, { keyframes } from "styled-components";
 import { BaseButton } from "../../styles/default";
+import { Spinner } from "@phosphor-icons/react";
 
 export const HeaderContainer = styled.header`
   padding: 2rem 0;
@@ -28,6 +29,16 @@ export const LocationButton = styled(BaseButton)`
   color: ${(props) => props.theme["purple-700"]};
   font-size: 0.875rem;
   gap: 0.25rem;
+`;
+
+const spin = keyframes`
+  to {
+    transform: rotate(360deg)
+  }
+`;
+
+export const SpinningIcon = styled(Spinner)`
+  animation: ${spin} 1s linear infinite
 `;
 
 export const CartButton = styled(BaseButton)`

--- a/src/components/PaymentButton/index.tsx
+++ b/src/components/PaymentButton/index.tsx
@@ -2,34 +2,28 @@ import { Bank, CreditCard, Money } from "@phosphor-icons/react";
 import { Payment } from "./styles";
 
 type PaymentButtonProps = {
-  name: "Cartão de crédito" | "Cartão de débito" | "Dinheiro",
-  icon: string,
-  isPaymentSelected: string,
-  onSelectionPayment: (type: string) => void
-}
+  name: string;
+  icon: string;
+  isPaymentSelected: string;
+  onSelectionPayment: (type: string) => void;
+};
 
 export function PaymentButton({
   name,
   icon,
   isPaymentSelected,
-  onSelectionPayment
+  onSelectionPayment,
 }: PaymentButtonProps) {
   return (
     <Payment
       onClick={() => onSelectionPayment(name)}
-      className={isPaymentSelected === name ? "active" :  ""}
+      className={isPaymentSelected === name ? "active" : ""}
     >
-      {icon === "creditCard" && (
-        <CreditCard size={16} />
-      )}
+      {icon === "creditCard" && <CreditCard size={16} />}
 
-      {icon === "bank" && (
-        <Bank size={16} />
-      )}
+      {icon === "bank" && <Bank size={16} />}
 
-      {icon === "money" && (
-        <Money size={16} />
-      )}
+      {icon === "money" && <Money size={16} />}
 
       {name}
     </Payment>

--- a/src/components/PaymentButton/index.tsx
+++ b/src/components/PaymentButton/index.tsx
@@ -2,7 +2,7 @@ import { Bank, CreditCard, Money } from "@phosphor-icons/react";
 import { Payment } from "./styles";
 
 type PaymentButtonProps = {
-  name: string,
+  name: "Cartão de crédito" | "Cartão de débito" | "Dinheiro",
   icon: string,
   isPaymentSelected: string,
   onSelectionPayment: (type: string) => void

--- a/src/components/QuantityAction/styles.ts
+++ b/src/components/QuantityAction/styles.ts
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 interface QuantityContainerProps {
-  $componentHeight?: number
+  $componentHeight?: number;
 }
 
 export const QuantityContainer = styled.div<QuantityContainerProps>`
@@ -46,9 +46,7 @@ export const QuantityContainer = styled.div<QuantityContainerProps>`
     font-size: 1rem;
     color: ${(props) => props.theme["brown-900"]};
 
-    [type="number"] {
-      -moz-appearance: textfield;
-    }
+    -moz-appearance: textfield;
 
     &::-webkit-outer-spin-button,
     &::-webkit-inner-spin-button {

--- a/src/contexts/CartContext.tsx
+++ b/src/contexts/CartContext.tsx
@@ -1,5 +1,15 @@
-import { ReactNode, createContext, useEffect, useReducer, useState } from "react";
-import { CheckoutSummary, Product, cartReducer } from "../reducers/cart/reducer";
+import {
+  ReactNode,
+  createContext,
+  useEffect,
+  useReducer,
+  useState,
+} from "react";
+import {
+  CheckoutSummary,
+  Product,
+  cartReducer,
+} from "../reducers/cart/reducer";
 import { products } from "../json/products";
 import {
   addProductToCartAction,
@@ -7,26 +17,26 @@ import {
   sendOrderAction,
   sumProductToCartAction,
   updatePriceAction,
-  updateProductQuantityAction
+  updateProductQuantityAction,
 } from "../reducers/cart/actions";
 import { addressFormData } from "../components/AddressForm";
 import { useNavigate } from "react-router-dom";
 
 interface CartContextType {
-  cart: Product[],
-  productList: Product[],
-  address: addressFormData | null,
-  payment: string,
-  summary: CheckoutSummary,
-  addProductToCart: (id: number) => void,
-  updateProductQuantity: (productId: number, quantity: number) => void,
-  removeProductFromCart: (id: number) => void,
-  selectPaymentMethod: (method: string) => void,
-  sendCheckoutOrder: (address: addressFormData) => void,
+  cart: Product[];
+  productList: Product[];
+  address: addressFormData | null;
+  payment: string;
+  summary: CheckoutSummary;
+  addProductToCart: (id: number) => void;
+  updateProductQuantity: (productId: number, quantity: number) => void;
+  removeProductFromCart: (id: number) => void;
+  selectPaymentMethod: (method: string) => void;
+  sendCheckoutOrder: (address: addressFormData) => void;
 }
 
 interface CartContextProviderProps {
-  children: ReactNode
+  children: ReactNode;
 }
 
 export const CartContext = createContext({} as CartContextType);
@@ -34,25 +44,23 @@ export const CartContext = createContext({} as CartContextType);
 export function CartContextProvider({ children }: CartContextProviderProps) {
   const navigate = useNavigate();
   const [payment, setPayment] = useState("");
-  const [cartState, dispatch] = useReducer(
-    cartReducer, {
-      cart: [],
-      productList: products,
-      address: null,
-      paymentMethod: payment,
-      summary: {
-        items: 0,
-        delivery: 3.5,
-        total: 0
-      }
-    }
-  );
+  const [cartState, dispatch] = useReducer(cartReducer, {
+    cart: [],
+    productList: products,
+    address: null,
+    paymentMethod: payment,
+    summary: {
+      items: 0,
+      delivery: 3.5,
+      total: 0,
+    },
+  });
 
   const { cart, productList, address, summary } = cartState;
 
   function addProductToCart(id: number) {
-    const filterProducts = productList.find(item => item.id === id);
-    const productAlreadyAddedToCart = cart.find(product => product.id === id);
+    const filterProducts = productList.find((item) => item.id === id);
+    const productAlreadyAddedToCart = cart.find((product) => product.id === id);
 
     if (filterProducts) {
       if (productAlreadyAddedToCart) {
@@ -85,18 +93,20 @@ export function CartContextProvider({ children }: CartContextProviderProps) {
   }, [cart]);
 
   return (
-    <CartContext.Provider value={{
-      cart,
-      productList,
-      address,
-      payment,
-      summary,
-      addProductToCart,
-      updateProductQuantity,
-      removeProductFromCart,
-      selectPaymentMethod,
-      sendCheckoutOrder
-    }}>
+    <CartContext.Provider
+      value={{
+        cart,
+        productList,
+        address,
+        payment,
+        summary,
+        addProductToCart,
+        updateProductQuantity,
+        removeProductFromCart,
+        selectPaymentMethod,
+        sendCheckoutOrder,
+      }}
+    >
       {children}
     </CartContext.Provider>
   );

--- a/src/contexts/LocationContext.tsx
+++ b/src/contexts/LocationContext.tsx
@@ -25,10 +25,13 @@ export function LocationContextProvider({ children }: LocationContextProviderPro
 
   async function handleLocation(position: any) {
     setIsLoading(true);
+    setLocationError("");
 
     try {
       const { latitude, longitude } = position.coords;
-      const getLocation = await fetch(`https://nominatim.openstreetmap.org/reverse?format=json&lat=${latitude}&lon=${longitude}`);
+      const getLocation = await fetch(
+        `https://nominatim.openstreetmap.org/reverse?format=json&lat=${latitude}&lon=${longitude}`
+      );
       const locationResponse = await getLocation.json();
 
       setLocation({
@@ -36,9 +39,9 @@ export function LocationContextProvider({ children }: LocationContextProviderPro
         state: locationResponse.address.state
       });
     } catch(error) {
-      setLocationError("Desculpe, não conseguimos encontrar seu endereço. Tente novamente mais tarde.");
+      setLocationError("Desculpe, não conseguimos encontrar sua localização. Tente novamente mais tarde.");
       console.error(
-        "Desculpe, não conseguimos encontrar seu endereço. Tente novamente mais tarde. ",
+        "Desculpe, não conseguimos encontrar sua localização. Tente novamente mais tarde. ",
         error
       );
     } finally {
@@ -51,11 +54,10 @@ export function LocationContextProvider({ children }: LocationContextProviderPro
       setIsLocationLoaded(true);
       navigator.geolocation.getCurrentPosition(handleLocation, () => {
         setIsLocationLoaded(false);
-        setLocationError("Desculpe, não conseguimos encontrar sua localização.");
+        setLocationError(
+          "Desculpe, não conseguimos encontrar sua localização. Verifique as configurações do seu navegador."
+        );
       });
-    } else {
-      setLocationError("Desculpe, Geolocalização não suportada pelo navegador.");
-      console.error("Geolocalização não suportada pelo navegador.");
     }
   }, [isLocationLoaded]);
 

--- a/src/contexts/LocationContext.tsx
+++ b/src/contexts/LocationContext.tsx
@@ -7,6 +7,8 @@ interface LocationData {
 
 interface LocationContextType {
   location: LocationData | null
+  isLoading: boolean
+  locationError: string
 }
 
 interface LocationContextProviderProps {
@@ -20,8 +22,6 @@ export function LocationContextProvider({ children }: LocationContextProviderPro
   const [isLocationLoaded, setIsLocationLoaded] = useState(false);
   const [locationError, setLocationError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
-
-  // https://nominatim.org/release-docs/develop/api/Reverse/
 
   async function handleLocation(position: any) {
     setIsLoading(true);
@@ -51,15 +51,16 @@ export function LocationContextProvider({ children }: LocationContextProviderPro
       setIsLocationLoaded(true);
       navigator.geolocation.getCurrentPosition(handleLocation, () => {
         setIsLocationLoaded(false);
-        setLocationError("Desculpa, não conseguimos encontrar sua localização!");
+        setLocationError("Desculpe, não conseguimos encontrar sua localização.");
       });
     } else {
-      console.log("Geolocalização não suportada no navegador!");
+      setLocationError("Desculpe, Geolocalização não suportada pelo navegador.");
+      console.error("Geolocalização não suportada pelo navegador.");
     }
   }, [isLocationLoaded]);
 
   return (
-    <LocationContext.Provider value={{ location }}>
+    <LocationContext.Provider value={{ location, isLoading, locationError }}>
       {children}
     </LocationContext.Provider>
   );

--- a/src/contexts/LocationContext.tsx
+++ b/src/contexts/LocationContext.tsx
@@ -1,23 +1,31 @@
-import { createContext, ReactNode, useContext, useEffect, useState } from "react";
+import {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
 
 interface LocationData {
-  city: string
-  state: string
+  city: string;
+  state: string;
 }
 
 interface LocationContextType {
-  location: LocationData | null
-  isLoading: boolean
-  locationError: string
+  location: LocationData | null;
+  isLoading: boolean;
+  locationError: string;
 }
 
 interface LocationContextProviderProps {
-  children: ReactNode
+  children: ReactNode;
 }
 
 export const LocationContext = createContext({} as LocationContextType);
 
-export function LocationContextProvider({ children }: LocationContextProviderProps) {
+export function LocationContextProvider({
+  children,
+}: LocationContextProviderProps) {
   const [location, setLocation] = useState<LocationData | null>(null);
   const [isLocationLoaded, setIsLocationLoaded] = useState(false);
   const [locationError, setLocationError] = useState("");
@@ -30,17 +38,21 @@ export function LocationContextProvider({ children }: LocationContextProviderPro
     try {
       const { latitude, longitude } = position.coords;
       const getLocation = await fetch(
+        // eslint-disable-next-line max-len
         `https://nominatim.openstreetmap.org/reverse?format=json&lat=${latitude}&lon=${longitude}`
       );
       const locationResponse = await getLocation.json();
 
       setLocation({
         city: locationResponse.address.city,
-        state: locationResponse.address.state
+        state: locationResponse.address.state,
       });
-    } catch(error) {
-      setLocationError("Desculpe, não conseguimos encontrar sua localização. Tente novamente mais tarde.");
+    } catch (error) {
+      setLocationError(
+        "Desculpe, não conseguimos encontrar sua localização. Tente novamente mais tarde."
+      );
       console.error(
+        // eslint-disable-next-line max-len
         "Desculpe, não conseguimos encontrar sua localização. Tente novamente mais tarde. ",
         error
       );
@@ -55,6 +67,7 @@ export function LocationContextProvider({ children }: LocationContextProviderPro
       navigator.geolocation.getCurrentPosition(handleLocation, () => {
         setIsLocationLoaded(false);
         setLocationError(
+          // eslint-disable-next-line max-len
           "Desculpe, não conseguimos encontrar sua localização. Verifique as configurações do seu navegador."
         );
       });

--- a/src/contexts/LocationContext.tsx
+++ b/src/contexts/LocationContext.tsx
@@ -23,7 +23,7 @@ export function LocationContextProvider({ children }: LocationContextProviderPro
   const [locationError, setLocationError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
 
-  async function handleLocation(position: any) {
+  async function handleLocation(position: GeolocationPosition) {
     setIsLoading(true);
     setLocationError("");
 

--- a/src/contexts/LocationContext.tsx
+++ b/src/contexts/LocationContext.tsx
@@ -1,0 +1,70 @@
+import { createContext, ReactNode, useContext, useEffect, useState } from "react";
+
+interface LocationData {
+  city: string
+  state: string
+}
+
+interface LocationContextType {
+  location: LocationData | null
+}
+
+interface LocationContextProviderProps {
+  children: ReactNode
+}
+
+export const LocationContext = createContext({} as LocationContextType);
+
+export function LocationContextProvider({ children }: LocationContextProviderProps) {
+  const [location, setLocation] = useState<LocationData | null>(null);
+  const [isLocationLoaded, setIsLocationLoaded] = useState(false);
+  const [locationError, setLocationError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  // https://nominatim.org/release-docs/develop/api/Reverse/
+
+  async function handleLocation(position: any) {
+    setIsLoading(true);
+
+    try {
+      const { latitude, longitude } = position.coords;
+      const getLocation = await fetch(`https://nominatim.openstreetmap.org/reverse?format=json&lat=${latitude}&lon=${longitude}`);
+      const locationResponse = await getLocation.json();
+
+      setLocation({
+        city: locationResponse.address.city,
+        state: locationResponse.address.state
+      });
+    } catch(error) {
+      setLocationError("Desculpe, não conseguimos encontrar seu endereço. Tente novamente mais tarde.");
+      console.error(
+        "Desculpe, não conseguimos encontrar seu endereço. Tente novamente mais tarde. ",
+        error
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (!isLocationLoaded && navigator.geolocation) {
+      setIsLocationLoaded(true);
+      navigator.geolocation.getCurrentPosition(handleLocation, () => {
+        setIsLocationLoaded(false);
+        setLocationError("Desculpa, não conseguimos encontrar sua localização!");
+      });
+    } else {
+      console.log("Geolocalização não suportada no navegador!");
+    }
+  }, [isLocationLoaded]);
+
+  return (
+    <LocationContext.Provider value={{ location }}>
+      {children}
+    </LocationContext.Provider>
+  );
+}
+
+export const useLocation = () => {
+  return useContext(LocationContext);
+};

--- a/src/pages/Checkout/index.tsx
+++ b/src/pages/Checkout/index.tsx
@@ -1,8 +1,4 @@
-import {
-  CurrencyDollar,
-  MapPinLine,
-  Trash
-} from "@phosphor-icons/react";
+import { CurrencyDollar, MapPinLine, Trash } from "@phosphor-icons/react";
 import {
   CheckoutContainer,
   CheckoutEmptyContainer,
@@ -13,7 +9,7 @@ import {
   CheckoutSummaryContent,
   CheckoutTitleSection,
   PaymentButtonsSection,
-  RemoveProductButton
+  RemoveProductButton,
 } from "./styles";
 import { formatReal } from "../../helpers/formatReal";
 import { QuantityAction } from "../../components/QuantityAction";
@@ -25,13 +21,8 @@ import { payments } from "../../json/payments";
 import { PaymentButton } from "../../components/PaymentButton";
 
 export function Checkout() {
-  const {
-    cart,
-    payment,
-    summary,
-    removeProductFromCart,
-    selectPaymentMethod
-  } = useContext(CartContext);
+  const { cart, payment, summary, removeProductFromCart, selectPaymentMethod } =
+    useContext(CartContext);
 
   function removeFromCart(id: number) {
     removeProductFromCart(id);
@@ -60,8 +51,8 @@ export function Checkout() {
               <CheckoutTitleSection $iconcolor="purple">
                 <CurrencyDollar size={20} />
                 <p>
-                  <span>Pagamento</span>
-                  O pagamento é feito na entrega. Escolha a forma que deseja pagar
+                  <span>Pagamento</span>O pagamento é feito na entrega. Escolha
+                  a forma que deseja pagar
                 </p>
               </CheckoutTitleSection>
 
@@ -107,7 +98,10 @@ export function Checkout() {
                       </div>
                     </div>
                     <div className="price">
-                      <p><span>R$</span>{formatReal(item.price)}</p>
+                      <p>
+                        <span>R$</span>
+                        {formatReal(item.price)}
+                      </p>
                     </div>
                   </div>
                 ))}
@@ -144,9 +138,11 @@ export function Checkout() {
         <CheckoutEmptyContainer>
           <h1>Seu carrinho está vazio</h1>
           <p>Adicione produtos no seu carrinho para seguir com a compra</p>
-          <Link to="/" title="Home" role="button">Continuar comprando</Link>
+          <Link to="/" title="Home" role="button">
+            Continuar comprando
+          </Link>
         </CheckoutEmptyContainer>
       )}
     </CheckoutContainer>
   );
-} 
+}


### PR DESCRIPTION
### Adição de geolocalização

Criação de um contexto que lida com a busca da localização utilizando a `Geolocation API` nativa do próprio browser, já retornando a informação que será usada no botão existe no header. Caso o usuário permita o uso da localização no navegador, a cidade e o estado serão exibidos, caso não, ficará um botão de loading eterno, e ao clicar exibirá uma mensagem que a localização foi bloqueada pelo usuário.

Adição de uma nova biblioteca de toast, que retornará um status para o usuário quando ele não permitir a localização ou caso algum erro aconteça nas APIs.

Também foi feito um ajuste no input do tipo `number`, para não exibir as arrows no firefox.